### PR TITLE
Update optim.py

### DIFF
--- a/src/pymc3_ext/optim.py
+++ b/src/pymc3_ext/optim.py
@@ -131,7 +131,7 @@ def optimize(
     # Coerce the output into the right format
     point = get_point(wrapper, x)
 
-    if verbose:
+    if verbose and info is not None:
         sys.stderr.write("message: {0}\n".format(info.message))
         sys.stderr.write("logp: {0} -> {1}\n".format(-initial, -info.fun))
         if not np.isfinite(info.fun):


### PR DESCRIPTION
If the optimizer reaches the maximum number of iterations, `info` is set to `None`. If `verbose` is `True` (default), the code chokes when trying to print things like `info.message`. This PR skips those informational messages to ensure the code returns w/o error.